### PR TITLE
refactor: remove redundant code in config initialization

### DIFF
--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -86,13 +86,13 @@ func (c *File) Location() (path string, err error) {
 	if rhoasConfig := os.Getenv(EnvName); rhoasConfig != "" {
 		path = rhoasConfig
 	} else {
-		rhoasCfgDir, err := DefaultDir()
-		if err != nil {
-			return "", err
+		rhoasCfgDir, e := DefaultDir()
+		if e != nil {
+			return "", e
 		}
 		path = filepath.Join(rhoasCfgDir, "plugin_config.json")
-		if err != nil {
-			return "", err
+		if e != nil {
+			return "", e
 		}
 	}
 

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -29,18 +29,15 @@ func (c *File) Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, err = os.Stat(file)
-	if os.IsNotExist(err) {
-		return nil, err
-	}
-	if err != nil {
-		return nil, fmt.Errorf(errorFormat, "unable to check if config file exists", err)
-	}
+
 	// #nosec G304
 	data, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf(errorFormat, "unable to read config file", err)
+	if os.IsNotExist(err) {
+		return &Config{}, nil
+	} else if err != nil {
+		return nil, err
 	}
+
 	var cfg Config
 	err = json.Unmarshal(data, &cfg)
 	if err != nil {
@@ -59,16 +56,7 @@ func (c *File) Save(cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("%v: %w", "unable to marshal config", err)
 	}
-	rhoasCfgDir, err := DefaultDir()
-	if err != nil {
-		return err
-	}
-	if _, err = os.Stat(rhoasCfgDir); os.IsNotExist(err) {
-		err = os.Mkdir(rhoasCfgDir, 0o700)
-		if err != nil {
-			return err
-		}
-	}
+
 	err = ioutil.WriteFile(file, data, 0o600)
 	if err != nil {
 		return fmt.Errorf(errorFormat, "unable to save config", err)
@@ -107,6 +95,14 @@ func (c *File) Location() (path string, err error) {
 			return "", err
 		}
 	}
+
+	if _, err = os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+		e := os.MkdirAll(filepath.Dir(path), 0700)
+		if e != nil {
+			return "", e
+		}
+	}
+
 	return path, nil
 }
 


### PR DESCRIPTION
### Description

Made changes so as to reduce the Config initialization code block,

- From this:
  ```golang
  func initConfig(f *factory.Factory) error {
	  if !config.HasCustomLocation() {
		  rhoasCfgDir, err := config.DefaultDir()
		  if err != nil {
			  return err
		  }
  
		  // create rhoas config directory
		  if _, err = os.Stat(rhoasCfgDir); os.IsNotExist(err) {
			  err = os.MkdirAll(rhoasCfgDir, 0o700)
			  if err != nil {
				  return err
			  }
		  }
	  }
  
	  cfgFile, err := f.Config.Load()
  
	  if cfgFile != nil {
		  return err
	  }
  
	  if !os.IsNotExist(err) {
		  return err
	  }
  
	  cfgFile = &config.Config{}
	  if err := f.Config.Save(cfgFile); err != nil {
		  return err
	  }
	  return nil
  }
  
  err = initConfig(cmdFactory)
  if err != nil {
	  logger.Errorf(localizer.LocalizeByID("main.config.error", localize.NewEntry("Error", err)))
	  os.Exit(1)
  }
  ```

- To this:
  ```golang
  cfgFile, err := f.Config.Load()
  if err != nil {
	  fmt.Println(f.IOStreams.ErrOut, err)
	  os.Exit(1)
  }
  
  if err := f.Config.Save(cfgFile); err != nil {
	  fmt.Fprintln(os.Stderr, err)
	  os.Exit(1)
  }
  ```


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change
- [x] Other (please specify): Refactor

### Checklist

- [ ] Documentation added for the feature
- [x] CI and all relevant tests are passing
- [ ] Code Review completed
- [ ] Verified independently by reviewer